### PR TITLE
Don't Reassign Compilation before OnComplete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+.fake
+.ionide

--- a/src/CodeGeneration.Roslyn.Engine/CompilationGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Engine/CompilationGenerator.cs
@@ -101,7 +101,7 @@ namespace Cythral.CodeGeneration.Roslyn.Engine
             // For incremental build, we want to consider the input->output files as well as the assemblies involved in code generation.
             DateTime assembliesLastModified = GetLastModifiedAssemblyTime();
 
-            CSharpCompilation completedCompilation;
+            CSharpCompilation completedCompilation = null;
             var fileFailures = new List<Exception>();
             var generatorsUsed = new HashSet<ICodeGenerator>();
 

--- a/src/CodeGeneration.Roslyn.Engine/CompilationGenerator.cs
+++ b/src/CodeGeneration.Roslyn.Engine/CompilationGenerator.cs
@@ -101,6 +101,7 @@ namespace Cythral.CodeGeneration.Roslyn.Engine
             // For incremental build, we want to consider the input->output files as well as the assemblies involved in code generation.
             DateTime assembliesLastModified = GetLastModifiedAssemblyTime();
 
+            CSharpCompilation completedCompilation;
             var fileFailures = new List<Exception>();
             var generatorsUsed = new HashSet<ICodeGenerator>();
 
@@ -157,7 +158,7 @@ namespace Cythral.CodeGeneration.Roslyn.Engine
                                     }
                                 }
 
-                                compilation = compilation.AddSyntaxTrees(generatedSyntaxTree);
+                                completedCompilation = compilation.AddSyntaxTrees(generatedSyntaxTree);
                                 break;
                             }
                             catch (IOException ex) when (ex.HResult == ProcessCannotAccessFileHR && retriesLeft > 0)
@@ -179,7 +180,7 @@ namespace Cythral.CodeGeneration.Roslyn.Engine
                 }
             }
 
-            var onCompleteContext = new OnCompleteContext(IntermediateOutputDirectory, BuildProperties, compilation);
+            var onCompleteContext = new OnCompleteContext(IntermediateOutputDirectory, BuildProperties, completedCompilation);
 
             foreach (var generator in generatorsUsed)
             {


### PR DESCRIPTION
Don't reassign compilation before OnComplete happens - I have a feeling it is whats causing instance variables on the generator to be invalidated