### PR TITLE
Use Roslyn 3.7.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,7 +25,7 @@
     <OutputPath>$(MSBuildThisFileDirectory)../bin/$(MSBuildProjectName)/$(Configuration)/</OutputPath>
     <PackageOutputPath>$(MSBuildThisFileDirectory)../bin/Packages/$(Configuration)/</PackageOutputPath>
     <IsTestingOnlyProject>$(MSBuildProjectName.Contains('Test'))</IsTestingOnlyProject>
-    <RoslynNugetVersion>3.4.0</RoslynNugetVersion>
+    <RoslynNugetVersion>3.7.0</RoslynNugetVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" !$(IsTestingOnlyProject) ">

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
-  "sdk": { "version": "3.1.100" },
+  "sdk": { "version": "3.1.301" },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "1.0.94"
   }

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/tags/v\\d\\.\\d"


### PR DESCRIPTION
Upgrading Roslyn to 3.7.0 and .NET Core SDK to 3.1.301